### PR TITLE
fix: Add action.yml to repository root for simpler usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ jobs:
           fetch-depth: 0
 
       - name: CodeBunny Review
-        uses: bdougie/codebunny/actions/codebunny@main
+        uses: bdougie/codebunny@main
         with:
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}
           continue-org: ${{ vars.CONTINUE_ORG }}
@@ -143,7 +143,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: CodeBunny Review
-        uses: bdougie/codebunny/actions/codebunny@main
+        uses: bdougie/codebunny@main
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,63 @@
+name: 'CodeBunny AI Review'
+description: 'AI-powered code reviews using Continue Agent on pull requests'
+author: 'Brian Douglas'
+inputs:
+  continue-api-key:
+    description: 'API key for Continue service'
+    required: true
+  github-token:
+    description: 'GitHub token for API access (defaults to GITHUB_TOKEN if not provided)'
+    required: false
+    default: ''
+  continue-org:
+    description: 'Continue organization/username from Continue Hub'
+    required: true
+  continue-config:
+    description: 'Continue assistant path (format: username/assistant-name)'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install Continue CLI
+      shell: bash
+      run: |
+        echo "Installing Continue CLI..."
+        # Install locally in action directory
+        cd ${{ github.action_path }}/actions/codebunny
+        npm install @continuedev/cli@1.4.30
+        # Add to PATH
+        echo "${{ github.action_path }}/actions/codebunny/node_modules/.bin" >> $GITHUB_PATH
+
+    - name: Install action dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}/actions/codebunny
+      run: |
+        echo "Installing action dependencies..."
+        npm init -y
+        npm install @actions/core @actions/github @actions/exec js-yaml glob @octokit/rest
+        npm install --save-dev @types/js-yaml @types/node typescript tsx
+
+    - name: Run CodeBunny Review
+      shell: bash
+      working-directory: ${{ github.action_path }}/actions/codebunny
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        CONTINUE_API_KEY: ${{ inputs.continue-api-key }}
+        CONTINUE_ORG: ${{ inputs.continue-org }}
+        CONTINUE_CONFIG: ${{ inputs.continue-config }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_CONTINUE_API_KEY: ${{ inputs.continue-api-key }}
+        INPUT_CONTINUE_ORG: ${{ inputs.continue-org }}
+        INPUT_CONTINUE_CONFIG: ${{ inputs.continue-config }}
+      run: |
+        echo "Running CodeBunny Review..."
+        npx tsx index.ts
+
+branding:
+  icon: 'code'
+  color: 'blue'


### PR DESCRIPTION
## Summary

This PR addresses issue #3 by adding an `action.yml` file to the repository root. This allows users to reference the action using the simpler, more standard path:

```yaml
uses: bdougie/codebunny@main
```

Instead of the current subdirectory path:
```yaml
uses: bdougie/codebunny/actions/codebunny@main
```

## Changes

- Added `action.yml` to the repository root that delegates to the existing action in `actions/codebunny/`
- Updated README.md examples to use the simpler path
- Maintained backward compatibility - the subdirectory path still works

## Implementation Details

The root `action.yml` is a composite action that:
1. Maintains all the same inputs and configuration as the original
2. Adjusts the working directories to point to `actions/codebunny/` 
3. Ensures all relative paths work correctly from the root context

## Testing

- [x] Test that the new root path works correctly
- [ ] Verify backward compatibility with the subdirectory path
- [x] Ensure all action functionality remains intact

Fixes #3