### PR TITLE
Add semantic versioning and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build action
+        working-directory: actions/codebunny
+        run: |
+          npm ci
+          npm run build
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Extract major version
+        id: major
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          echo "MAJOR=$MAJOR" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          # Get previous tag
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          
+          # Generate changelog
+          if [ -n "$PREV_TAG" ]; then
+            echo "NOTES<<EOF" >> $GITHUB_OUTPUT
+            echo "## What's Changed" >> $GITHUB_OUTPUT
+            git log $PREV_TAG..HEAD --pretty=format:"- %s (%h)" --no-merges >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "NOTES=Initial release of CodeBunny 🐰" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.version.outputs.VERSION }}
+          release_name: ${{ steps.version.outputs.VERSION }}
+          body: ${{ steps.notes.outputs.NOTES }}
+          draft: false
+          prerelease: false
+
+      - name: Update major version tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa ${{ steps.major.outputs.MAJOR }} -m "Update ${{ steps.major.outputs.MAJOR }} to ${{ steps.version.outputs.VERSION }}"
+          git push origin ${{ steps.major.outputs.MAJOR }} --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to CodeBunny will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Release workflow for automated versioning
+- CHANGELOG.md for tracking changes
+- Semantic versioning strategy
+
+## [1.0.0] - TBD
+
+### Added
+- AI-powered code reviews using Continue Agent
+- Codebase pattern analysis
+- Custom rules support via `.continue/rules/`
+- Interactive commands with `@codebunny` mentions
+- Sticky progress comments
+- GitHub App authentication support
+- BYOK (Bring Your Own Key) support
+- Review metrics tracking
+- Security, testing, and TypeScript rule examples
+- Comprehensive documentation and setup guides
+
+### Features
+- Automated reviews on PR creation and updates
+- Context-aware feedback based on project patterns
+- Privacy-first design (runs in GitHub Actions)
+- Support for JavaScript/TypeScript projects
+- Integration with Continue Hub or self-hosted Continue instances
+
+---
+
+## Release Types
+
+### Major Version (x.0.0)
+Breaking changes that require user action:
+- Changes to workflow configuration format
+- Removed or renamed inputs
+- Changes to authentication requirements
+- Incompatible API updates
+
+### Minor Version (0.x.0)
+New features, backward compatible:
+- New review capabilities
+- Additional language support
+- Enhanced metrics
+- New configuration options
+
+### Patch Version (0.0.x)
+Bug fixes and minor improvements:
+- Bug fixes
+- Documentation updates
+- Performance improvements
+- Dependency updates
+
+---
+
+[Unreleased]: https://github.com/bdougie/codebunny/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/bdougie/codebunny/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ CodeBunny is a GitHub Action that provides intelligent, context-aware code revie
 
 ## Installation
 
+### Versioning
+
+CodeBunny follows [Semantic Versioning](https://semver.org/). We recommend pinning to a specific major version for stability:
+
+```yaml
+# Recommended: Pin to major version (gets latest features and fixes)
+- uses: bdougie/codebunny@v1
+
+# Pin to specific version (maximum stability)
+- uses: bdougie/codebunny@v1.0.0
+
+# Always latest (not recommended for production)
+- uses: bdougie/codebunny@main
+```
+
+**Version Types:**
+- **Major (v1, v2)** - May include breaking changes
+- **Minor (v1.1, v1.2)** - New features, backward compatible
+- **Patch (v1.0.1, v1.0.2)** - Bug fixes only
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
+
 ### Prerequisites
 
 - A GitHub repository with pull requests
@@ -99,7 +121,7 @@ jobs:
           fetch-depth: 0
 
       - name: CodeBunny Review
-        uses: bdougie/codebunny@main
+        uses: bdougie/codebunny@v1
         with:
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}
           continue-org: ${{ vars.CONTINUE_ORG }}
@@ -143,7 +165,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: CodeBunny Review
-        uses: bdougie/codebunny@main
+        uses: bdougie/codebunny@v1
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,158 @@
+# Release Process
+
+This document describes how to create new releases for CodeBunny.
+
+## Semantic Versioning
+
+CodeBunny follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (v1.0.0 → v2.0.0): Breaking changes that require user action
+  - Changes to workflow configuration format
+  - Removed or renamed inputs
+  - Incompatible API updates
+  
+- **MINOR** (v1.0.0 → v1.1.0): New features, backward compatible
+  - New review capabilities
+  - Additional language support
+  - New configuration options
+  
+- **PATCH** (v1.0.0 → v1.0.1): Bug fixes and improvements
+  - Bug fixes
+  - Documentation updates
+  - Dependency updates
+
+## Release Checklist
+
+Before creating a release:
+
+- [ ] All tests pass
+- [ ] Action builds successfully (`cd actions/codebunny && npm run build`)
+- [ ] CHANGELOG.md is updated with changes
+- [ ] Documentation is up to date
+- [ ] Breaking changes are clearly documented (for major releases)
+- [ ] Migration guide is provided (for major releases)
+
+## Creating a Release
+
+### Option 1: Using the Helper Script (Recommended)
+
+```bash
+# Create and tag the release
+./scripts/create-release.sh v1.0.0
+
+# Review the changes
+git show v1.0.0
+
+# Push the tag to trigger the release workflow
+git push origin v1.0.0
+```
+
+### Option 2: Manual Process
+
+```bash
+# Ensure you're on main and up to date
+git checkout main
+git pull origin main
+
+# Build the action
+cd actions/codebunny
+npm ci
+npm run build
+cd ../..
+
+# Create annotated tag
+git tag -a v1.0.0 -m "Release v1.0.0"
+
+# Push the tag
+git push origin v1.0.0
+```
+
+## What Happens After Pushing a Tag
+
+1. The `.github/workflows/release.yml` workflow triggers automatically
+2. The action is built and bundled
+3. A GitHub Release is created with auto-generated release notes
+4. The major version tag (e.g., `v1`) is updated to point to the new release
+
+This means users can reference:
+- `bdougie/codebunny@v1` - Always gets latest v1.x.x
+- `bdougie/codebunny@v1.0.0` - Pinned to specific version
+- `bdougie/codebunny@main` - Always latest (not recommended)
+
+## Updating CHANGELOG
+
+Before each release, update `CHANGELOG.md`:
+
+```markdown
+## [1.1.0] - 2024-01-15
+
+### Added
+- New feature description
+
+### Changed
+- Changed feature description
+
+### Fixed
+- Bug fix description
+
+### Deprecated
+- Deprecated feature description
+
+### Removed
+- Removed feature description
+
+### Security
+- Security fix description
+```
+
+## Post-Release Tasks
+
+After creating a release:
+
+- [ ] Verify the GitHub Release was created successfully
+- [ ] Check that the major version tag was updated (e.g., `v1` → latest v1.x.x)
+- [ ] Test the new version in a test repository
+- [ ] Announce the release (if significant)
+- [ ] Close any related issues/PRs
+
+## Hotfix Releases
+
+For urgent bug fixes:
+
+1. Create a branch from the tag: `git checkout -b hotfix/v1.0.1 v1.0.0`
+2. Make the fix and commit
+3. Create a new patch version tag: `git tag -a v1.0.1 -m "Hotfix: description"`
+4. Push the tag: `git push origin v1.0.1`
+5. Merge the fix back to main if needed
+
+## Rolling Back a Release
+
+If a release has critical issues:
+
+```bash
+# Delete the GitHub release (via web UI or GitHub CLI)
+gh release delete v1.0.0
+
+# Delete remote tag
+git push --delete origin v1.0.0
+
+# Delete local tag
+git tag -d v1.0.0
+
+# If the major version tag was updated, revert it
+git tag -fa v1 <previous-good-commit> -m "Revert to previous version"
+git push origin v1 --force
+```
+
+## Version Support Policy
+
+- **Current Major Version**: Receives all updates (features, fixes, security)
+- **Previous Major Version**: Receives security fixes for 6 months after new major release
+- **Older Versions**: No longer supported
+
+## Questions?
+
+If you have questions about the release process, please:
+- Open an issue for discussion
+- Review existing releases for examples
+- Check the GitHub Actions logs for release workflow details

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Script to create a new release for CodeBunny
+# Usage: ./scripts/create-release.sh v1.0.0
+
+set -e
+
+VERSION=$1
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: ./scripts/create-release.sh <version>"
+  echo "Example: ./scripts/create-release.sh v1.0.0"
+  exit 1
+fi
+
+# Validate version format
+if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Version must be in format v1.0.0"
+  exit 1
+fi
+
+echo "Creating release $VERSION..."
+
+# Ensure we're on main and up to date
+git checkout main
+git pull origin main
+
+# Build the action
+echo "Building action..."
+cd actions/codebunny
+npm ci
+npm run build
+cd ../..
+
+# Check if there are any uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: Working directory not clean. Commit or stash changes first."
+  exit 1
+fi
+
+# Create and push tag
+echo "Creating tag $VERSION..."
+git tag -a "$VERSION" -m "Release $VERSION"
+
+echo ""
+echo "Tag created successfully!"
+echo ""
+echo "To push the tag and trigger the release workflow, run:"
+echo "  git push origin $VERSION"
+echo ""
+echo "After the release workflow completes, the following will be available:"
+echo "  - Release $VERSION on GitHub"
+echo "  - Major version tag (e.g., v1) pointing to $VERSION"
+echo "  - Users can reference: bdougie/codebunny@v1 or bdougie/codebunny@$VERSION"


### PR DESCRIPTION
## Overview

This PR implements semantic versioning and automated release management for CodeBunny, addressing #8.

## Changes

### 🔧 Release Automation
- **** - Automated release workflow that:
  - Triggers on version tags (v*.*.*)
  - Builds and bundles the action
  - Creates GitHub releases with auto-generated notes
  - Updates major version tags (v1, v2) automatically

### 📝 Documentation
- **** - Tracks changes following Keep a Changelog format
- **** - Complete maintainer guide for release process
- **Usage: ./scripts/create-release.sh <version>
Example: ./scripts/create-release.sh v1.0.0** - Helper script for creating releases safely
- **** - Updated with:
  - Versioning section explaining semver strategy
  - All examples now use `@v1` instead of `@main`
  - Link to CHANGELOG

## User Benefits

After merging and releasing v1.0.0, users can:

```yaml
# Recommended: Pin to major version (gets latest features and fixes)
- uses: bdougie/codebunny@v1

# Pin to specific version (maximum stability)
- uses: bdougie/codebunny@v1.0.0

# Always latest (not recommended for production)
- uses: bdougie/codebunny@main
```

## Next Steps After Merge

1. Create the first release:
   ```bash
   ./scripts/create-release.sh v1.0.0
   git push origin v1.0.0
   ```

2. The release workflow will automatically:
   - Build the action
   - Create GitHub release with notes
   - Update the `v1` tag to point to `v1.0.0`

## Testing

- ✅ Release workflow syntax validated
- ✅ Helper script tested locally
- ✅ Documentation reviewed
- ✅ All examples updated

Closes #8